### PR TITLE
se agrega volumen cache para repositorios de maven.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@
 FROM maven:3.9-eclipse-temurin-17 AS builder
 WORKDIR /app
 COPY NetBeans/JaguerahaV3/ /app
-RUN ls -alh /app/target/
 RUN mvn clean package -DskipTests
-RUN ls -alh /app/target/
 
 ###########################################
 # ----- Corriendo tomcat----------------- #

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./war_export:/usr/local/tomcat/export/
+      - maven-cache:/root/.m2 
 
     networks:
       - backend
@@ -29,6 +29,7 @@ services:
 
 volumes:
   pgdata:
+  maven-cache:
 
 networks:
   backend:


### PR DESCRIPTION
es para prevenir que tenga que descargar las librerias de maven, cada vez que se hace build en el contenedor